### PR TITLE
Enhance login, signup form for password managers and enable required validation

### DIFF
--- a/frontend/src/screens/LoginScreen.js
+++ b/frontend/src/screens/LoginScreen.js
@@ -8,6 +8,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import TextField from "@mui/material/TextField";
 import Link from "@mui/material/Link";
 import Grid from "@mui/material/Grid";
+import InputLabel from "@mui/material/InputLabel";
 import Box from "@mui/material/Box";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import Typography from "@mui/material/Typography";
@@ -65,26 +66,47 @@ function LogInScreen() {
                     <Typography component="h1" variant="h5">
                         Log in
                     </Typography>
-                    <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3, width: "100%" }}>
+                        <InputLabel
+                            htmlFor="username"
+                            sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                        >
+                            Email
+                        </InputLabel>
                         <TextField
-                            margin="normal"
                             required
                             fullWidth
-                            id="email"
-                            label="Email Address"
+                            placeholder
+                            id="username"
                             name="email"
-                            autoComplete="email"
+                            autoComplete="username"
                             autoFocus
                             color="primary"
+                            sx={{ mb: 3 }}
                         />
+
+                        <Grid container>
+                            <Grid item xs>
+                                <InputLabel
+                                    htmlFor="current-password"
+                                    sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                                >
+                                    Password
+                                </InputLabel>
+                            </Grid>
+                            <Grid item>
+                                <Link href="#" variant="body2" underline="none">
+                                    Forgot password?
+                                </Link>
+                            </Grid>
+                        </Grid>
                         <TextField
-                            margin="normal"
                             required
                             fullWidth
+                            placeholder
                             name="password"
-                            label="Password"
                             type="password"
-                            id="password"
+                            id="current-password"
                             autoComplete="current-password"
                             color="primary"
                         />
@@ -98,18 +120,9 @@ function LogInScreen() {
                         >
                             Log In
                         </Button>
-                        <Grid container>
-                            <Grid item xs>
-                                <Link href="#" variant="body2">
-                                    Forgot password?
-                                </Link>
-                            </Grid>
-                            <Grid item>
-                                <Link href="/signup" variant="body2">
-                                    {"Don't have an account? Sign Up"}
-                                </Link>
-                            </Grid>
-                        </Grid>
+                        <Link href="/signup" variant="body2">
+                            Don't have an account? Sign Up
+                        </Link>
                     </Box>
                 </Box>
             </Container>

--- a/frontend/src/screens/ProfileSettingsScreen.js
+++ b/frontend/src/screens/ProfileSettingsScreen.js
@@ -168,12 +168,7 @@ function ProfileSettingsScreen() {
                     variant="outlined"
                     value={userData["snoosdigest/username"]}
                 />
-                <Box
-                    sx={{ width: "100%" }}
-                    component="form"
-                    onSubmit={handleProfileSubmit}
-                    noValidate
-                >
+                <Box sx={{ width: "100%" }} component="form" onSubmit={handleProfileSubmit}>
                     <InputLabel htmlFor="first-name" sx={{ color: "black", fontWeight: "bold" }}>
                         First Name
                     </InputLabel>
@@ -216,9 +211,9 @@ function ProfileSettingsScreen() {
                 </Typography>
                 <Divider sx={{ mt: 2, mb: 4, bgcolor: "grey.500" }} />
 
-                <Box component="form" onSubmit={handleChangePassword} noValidate sx={{ mt: 1 }}>
+                <Box component="form" onSubmit={handleChangePassword} sx={{ mt: 1 }}>
                     <InputLabel htmlFor="old-password" sx={{ color: "black", fontWeight: "bold" }}>
-                        Old password
+                        Old password *
                     </InputLabel>
                     <SettingsTextField
                         margin="normal"
@@ -232,7 +227,7 @@ function ProfileSettingsScreen() {
                         helperText={updatePasswordErrors.oldPassword}
                     />
                     <InputLabel htmlFor="new-password" sx={{ color: "black", fontWeight: "bold" }}>
-                        New password
+                        New password *
                     </InputLabel>
                     <SettingsTextField
                         margin="normal"
@@ -246,7 +241,7 @@ function ProfileSettingsScreen() {
                         helperText={updatePasswordErrors.newPassword}
                     />
                     <InputLabel htmlFor="old-password" sx={{ color: "black", fontWeight: "bold" }}>
-                        Confirm new password
+                        Confirm new password *
                     </InputLabel>
                     <SettingsTextField
                         margin="normal"

--- a/frontend/src/screens/SignUpScreen.js
+++ b/frontend/src/screens/SignUpScreen.js
@@ -7,6 +7,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import TextField from "@mui/material/TextField";
 import Link from "@mui/material/Link";
 import Grid from "@mui/material/Grid";
+import InputLabel from "@mui/material/InputLabel";
 import Box from "@mui/material/Box";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import Typography from "@mui/material/Typography";
@@ -57,47 +58,69 @@ function SignUpScreen() {
                     <Typography component="h1" variant="h5">
                         Sign up
                     </Typography>
-                    <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 3 }}>
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3 }}>
                         <Grid container spacing={2}>
                             <Grid item xs={12} sm={6}>
+                                <InputLabel
+                                    htmlFor="firstName"
+                                    sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                                >
+                                    First Name *
+                                </InputLabel>
                                 <TextField
                                     autoComplete="given-name"
                                     name="firstName"
                                     required
                                     fullWidth
                                     id="firstName"
-                                    label="First Name"
                                     autoFocus
                                 />
                             </Grid>
                             <Grid item xs={12} sm={6}>
+                                <InputLabel
+                                    htmlFor="lastName"
+                                    sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                                >
+                                    Last Name *
+                                </InputLabel>
                                 <TextField
                                     required
                                     fullWidth
                                     id="lastName"
-                                    label="Last Name"
                                     name="lastName"
                                     autoComplete="family-name"
                                 />
                             </Grid>
                             <Grid item xs={12}>
+                                <InputLabel
+                                    htmlFor="username"
+                                    sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                                >
+                                    Email *
+                                </InputLabel>
                                 <TextField
                                     required
                                     fullWidth
-                                    id="email"
-                                    label="Email Address"
+                                    placeholder
+                                    id="username"
                                     name="email"
-                                    autoComplete="email"
+                                    autoComplete="username"
                                 />
                             </Grid>
                             <Grid item xs={12}>
+                                <InputLabel
+                                    htmlFor="new-password"
+                                    sx={{ color: "black", fontWeight: "bold", mb: 1 }}
+                                >
+                                    Password *
+                                </InputLabel>
                                 <TextField
                                     required
                                     fullWidth
+                                    placeholder
                                     name="password"
-                                    label="Password"
                                     type="password"
-                                    id="password"
+                                    id="new-password"
                                     autoComplete="new-password"
                                 />
                             </Grid>
@@ -112,13 +135,9 @@ function SignUpScreen() {
                         >
                             Sign Up
                         </Button>
-                        <Grid container justifyContent="flex-end">
-                            <Grid item>
-                                <Link href="/login" variant="body2">
-                                    Already have an account? Log in
-                                </Link>
-                            </Grid>
-                        </Grid>
+                        <Link href="/login" variant="body2">
+                            Have an account? Log in
+                        </Link>
                     </Box>
                 </Box>
             </Container>


### PR DESCRIPTION
Previously client-side form validation (specifically required fields) were disabled. They have now been re-enabled and the login and sign up forms now use proper label tags to help password managers recognize fields better.